### PR TITLE
Revert because Skin Parser vertical bar problem has been fixed elsewhere...

### DIFF
--- a/apps/gui/skin_engine/skin_display.c
+++ b/apps/gui/skin_engine/skin_display.c
@@ -189,8 +189,6 @@ void draw_progressbar(struct gui_wps *gwps, int line, struct progressbar *pb)
     {
         /* we want to fill upwards which is technically inverted. */
         flags = INVERTFILL;
-        if (pb->type == SKIN_TOKEN_SETTINGBAR)
-            flags ^= INVERTFILL;
     }
     
     if (pb->invert_fill_direction)


### PR DESCRIPTION
Kugel commit 的bar翻轉加上我原本反向搞得很混亂, (ref: id c0a02c98c169e11fb4770e096cd1dd2e56b97f4d)
所以拿掉我的bar反向.
