### PR TITLE
add percentage x,y value support to BAR_PARAMS, %xl,%dr,%T,%St,%xl,%Cl

### DIFF
--- a/apps/gui/skin_engine/skin_parser.c
+++ b/apps/gui/skin_engine/skin_parser.c
@@ -398,8 +398,15 @@ static int parse_image_load(struct skin_element *element,
         subimages = get_param(element, 2)->data.number;
     else if (element->params_count > 3)
     {
-        x = get_param(element, 2)->data.number;
-        y = get_param(element, 3)->data.number;
+        if (get_param(element, 2)->type == PERCENT)
+            x = get_param(element, 2)->data.number * curr_vp->vp.width / 1000;
+        else  
+            x = get_param(element, 2)->data.number;
+        if (get_param(element, 3)->type == PERCENT)
+            y = get_param(element, 3)->data.number * curr_vp->vp.height / 1000;
+        else
+            y = get_param(element, 3)->data.number;
+
         if (element->params_count == 5)
             subimages = get_param(element, 4)->data.number;
     }
@@ -641,16 +648,27 @@ static int parse_drawrectangle( struct skin_element *element,
     if (!rect)
         return -1;
 
-    rect->x = get_param(element, 0)->data.number;
-    rect->y = get_param(element, 1)->data.number;
+    if (get_param(element, 0)->type == PERCENT)
+        rect->x = get_param(element, 0)->data.number * curr_vp->vp.width / 1000;
+    else  
+        rect->x = get_param(element, 0)->data.number;
+
+    if (get_param(element, 1)->type == PERCENT)
+        rect->y = get_param(element, 1)->data.number * curr_vp->vp.height / 1000;
+    else
+        rect->y = get_param(element, 1)->data.number;
 
     if (isdefault(get_param(element, 2)))
         rect->width = curr_vp->vp.width - rect->x;
+    else if (get_param(element, 2)->type == PERCENT)
+        rect->width = get_param(element, 2)->data.number * curr_vp->vp.width / 1000;
     else
         rect->width = get_param(element, 2)->data.number;
 
     if (isdefault(get_param(element, 3)))
         rect->height = curr_vp->vp.height - rect->y;
+    else if (get_param(element, 3)->type == PERCENT)
+        rect->height = get_param(element, 3)->data.number * curr_vp->vp.height / 1000;
     else
         rect->height = get_param(element, 3)->data.number;
 
@@ -923,7 +941,12 @@ static int parse_progressbar_tag(struct skin_element* element,
     /* (x, y, width, height, ...) */
     if (!isdefault(param))
     {
-        pb->x = param->data.number;
+        if (param->type == PERCENT)
+        {
+            pb->x = param->data.number *  vp->width / 1000;
+        }
+        else 
+            pb->x = param->data.number;
         if (pb->x < 0 || pb->x >= vp->width)
             return WPS_ERROR_INVALID_PARAM;
     }
@@ -933,7 +956,12 @@ static int parse_progressbar_tag(struct skin_element* element,
 
     if (!isdefault(param))
     {
-        pb->y = param->data.number;
+        if (param->type == PERCENT)
+        {
+           pb->y = param->data.number *  vp->height / 1000;
+        }
+        else
+            pb->y = param->data.number;
         if (pb->y < 0 || pb->y >= vp->height)
             return WPS_ERROR_INVALID_PARAM;
     }
@@ -943,7 +971,12 @@ static int parse_progressbar_tag(struct skin_element* element,
 
     if (!isdefault(param))
     {
-        pb->width = param->data.number;
+        if (param->type == PERCENT)
+        {
+           pb->width = param->data.number *  vp->width / 1000;
+        }
+        else
+            pb->width = param->data.number;
         if (pb->width <= 0 || (pb->x + pb->width) > vp->width)
             return WPS_ERROR_INVALID_PARAM;
     }
@@ -954,7 +987,12 @@ static int parse_progressbar_tag(struct skin_element* element,
     if (!isdefault(param))
     {
         int max;
-        pb->height = param->data.number;
+        if (param->type == PERCENT)
+        {
+           pb->height = param->data.number *  vp->height / 1000;
+        }
+        else 
+           pb->height = param->data.number;
         /* include y in check only if it was non-default */
         max = (pb->y > 0) ? pb->y + pb->height : pb->height;
         if (pb->height <= 0 || max > vp->height)
@@ -1210,6 +1248,18 @@ static int parse_albumart_load(struct skin_element* element,
     aa->y = get_param(element, 1)->data.number;
     aa->width = get_param(element, 2)->data.number;
     aa->height = get_param(element, 3)->data.number;
+
+    if (!isdefault(get_param(element, 0)) && get_param(element, 0)->type == PERCENT)
+        aa->x = get_param(element, 0)->data.number * curr_vp->vp.width / 1000;
+
+    if (!isdefault(get_param(element, 1)) && get_param(element, 1)->type == PERCENT)
+        aa->y = get_param(element, 1)->data.number * curr_vp->vp.height / 1000;
+
+    if (!isdefault(get_param(element, 2)) && get_param(element, 2)->type == PERCENT)
+        aa->width = get_param(element, 2)->data.number * curr_vp->vp.width / 1000;
+
+    if (!isdefault(get_param(element, 3)) && get_param(element, 3)->type == PERCENT)
+        aa->height = get_param(element, 3)->data.number * curr_vp->vp.height / 1000;
 
     aa->vp = PTRTOSKINOFFSET(skin_buffer, &curr_vp->vp);
     aa->draw_handle = -1;
@@ -1521,8 +1571,7 @@ static int parse_touchregion(struct skin_element *element,
         p = 1;
         /* "[SI]III[SI]|SS" is the param list. There MUST be 4 numbers
          * followed by at least one string. Verify that here */
-        if (element->params_count < 6 ||
-            get_param(element, 4)->type != INTEGER)
+        if (element->params_count < 6)
             return WPS_ERROR_INVALID_PARAM;
     }
     else
@@ -1530,11 +1579,48 @@ static int parse_touchregion(struct skin_element *element,
         region->label = PTRTOSKINOFFSET(skin_buffer, NULL);
         p = 0;
     }
+/*x*/
+    struct skin_tag_parameter *param = get_param(element, p);
+    region->x = 0;
+    if (!isdefault(param))
+    {
+        if (param->type == INTEGER) 
+            region->x = param->data.number;
+        else if (param->type == PERCENT) 
+            region->x = param->data.number * curr_vp->vp.width / 1000;
+    }
+/*y*/  
+    param = get_param(element, ++p);
+    region->y = 0; 
+    if (!isdefault(param))
+    {
+        if (param->type == INTEGER) 
+            region->y = param->data.number;
+        else if (param->type == PERCENT) 
+            region->y  =param->data.number * curr_vp->vp.width / 1000;
+    }
+/*width*/ 
+    param = get_param(element, ++p);
+    region->width = curr_vp->vp.width;
+    if (!isdefault(param))
+    {
+        if (param->type == INTEGER) 
+            region->width =param->data.number;
+        else if (param->type == PERCENT) 
+            region->width = curr_vp->vp.width  * param->data.number / 1000;
+    }
+/*height*/    
+    param = get_param(element, ++p);
+    region->height = curr_vp->vp.height;
+    if (!isdefault(param))
+    {
+        if (param->type == INTEGER) 
+            region->height =param->data.number;
+        else if (param->type == PERCENT) 
+            region->height = curr_vp->vp.height  * param->data.number / 1000;
+    }
+    p++;
 
-    region->x = get_param(element, p++)->data.number;
-    region->y = get_param(element, p++)->data.number;
-    region->width = get_param(element, p++)->data.number;
-    region->height = get_param(element, p++)->data.number;
     region->wvp = PTRTOSKINOFFSET(skin_buffer, curr_vp);
     region->armed = false;
     region->reverse_bar = false;

--- a/lib/skin_parser/tag_table.c
+++ b/lib/skin_parser/tag_table.c
@@ -22,7 +22,7 @@
 #include "tag_table.h"
 
 #include <string.h>
-#define BAR_PARAMS "?iiii|s*"
+#define BAR_PARAMS "?[iP][iP][iP][iP]|s*"
 /* The tag definition table */
 static const struct tag_info legal_tags[] = 
 {
@@ -176,13 +176,13 @@ static const struct tag_info legal_tags[] =
     { SKIN_TOKEN_DISABLE_THEME,         "wd", "", 0|NOBREAK },
     { SKIN_TOKEN_DRAW_INBUILTBAR,       "wi", "", SKIN_REFRESH_STATIC|NOBREAK },
     
-    { SKIN_TOKEN_IMAGE_PRELOAD,         "xl", "SF|III", 0|NOBREAK },
+    { SKIN_TOKEN_IMAGE_PRELOAD,         "xl", "SF|[IP][IP]I", 0|NOBREAK },
     { SKIN_TOKEN_IMAGE_PRELOAD_DISPLAY, "xd", "S|[IT]I", 0 },
     { SKIN_TOKEN_IMAGE_DISPLAY,         "x", "SF|II", SKIN_REFRESH_STATIC|NOBREAK },
     { SKIN_TOKEN_IMAGE_DISPLAY_9SEGMENT, "x9", "S", 0 },
     
     { SKIN_TOKEN_LOAD_FONT,             "Fl" , "IF|I", 0|NOBREAK },
-    { SKIN_TOKEN_ALBUMART_LOAD,         "Cl" , "IIII|ss", 0|NOBREAK },
+    { SKIN_TOKEN_ALBUMART_LOAD,         "Cl" , "[iP][iP][iP][iP]|ss", 0|NOBREAK },
     { SKIN_TOKEN_ALBUMART_DISPLAY,      "Cd" , "", SKIN_REFRESH_STATIC },
     { SKIN_TOKEN_ALBUMART_FOUND,        "C" , "", SKIN_REFRESH_STATIC },
     
@@ -214,7 +214,7 @@ static const struct tag_info legal_tags[] =
     { SKIN_TOKEN_IMAGE_BACKDROP,        "X"  , "f", SKIN_REFRESH_STATIC|NOBREAK },
     /* This uses the bar tag params also but the first item can be a string
      * and we don't allow no params. */
-    { SKIN_TOKEN_SETTING,               "St" , "[Si]|iiis*", SKIN_REFRESH_DYNAMIC },
+    { SKIN_TOKEN_SETTING,               "St" , "[Sip]|[ip][ip][ip]s*", SKIN_REFRESH_DYNAMIC },
     { SKIN_TOKEN_TRANSLATEDSTRING,      "Sx" , "S", SKIN_REFRESH_STATIC },
     { SKIN_TOKEN_LANG_IS_RTL,           "Sr" , "", SKIN_REFRESH_STATIC },
     
@@ -224,8 +224,7 @@ static const struct tag_info legal_tags[] =
      * [SI]III[SI]|SN <- SIIIIS|S or IIIIS|S 
      *  keep in sync with parse_touchregion() and parse_lasttouch() */
     { SKIN_TOKEN_LASTTOUCH,             "Tl" , "|[SD]D", SKIN_REFRESH_DYNAMIC },
-    { SKIN_TOKEN_TOUCHREGION,           "T"  , "[SI]III[SI]|S*", 0|NOBREAK },
-    
+    { SKIN_TOKEN_TOUCHREGION,           "T"  , "[Sip][ip][ip][ip][Sip]|S*", 0|NOBREAK },
     { SKIN_TOKEN_HAVE_TOUCH,            "Tp", "", FEATURE_TAG },
     
     { SKIN_TOKEN_CURRENT_SCREEN,        "cs", "", SKIN_REFRESH_DYNAMIC },
@@ -246,7 +245,7 @@ static const struct tag_info legal_tags[] =
     { SKIN_TOKEN_VAR_TIMEOUT,           "vl",   "S|D", SKIN_REFRESH_DYNAMIC },
 
     { SKIN_TOKEN_SUBSTRING,             "ss",   "IiT|s", SKIN_REFRESH_DYNAMIC },
-    { SKIN_TOKEN_DRAWRECTANGLE,         "dr",   "IIii|ss", SKIN_REFRESH_STATIC },
+    { SKIN_TOKEN_DRAWRECTANGLE,         "dr",   "[IP][IP][ip][ip]|ss", SKIN_REFRESH_STATIC },
     { SKIN_TOKEN_UNKNOWN,                ""   , "", 0 }
     /* Keep this here to mark the end of the table */
 };


### PR DESCRIPTION
主題只有%Vl能用百分率的區塊, 其他常用的只要一個算錯就破表很煩. 所以我參考%Vl的處理把其他幾個加上百分率的支援. 提升腳本的兼容性. 不強求pull. 純給予貴台一個參考
