### PR TITLE
Revert "Fix crashes on Android ports"

### DIFF
--- a/tools/configure
+++ b/tools/configure
@@ -27,7 +27,7 @@ bindir=
 libdir=
 sharedir=
 
-thread_support="HAVE_SIGALTSTACK_THREADS"
+thread_support="ASSEMBLER_THREADS"
 app_lcd_width=
 app_lcd_height=
 app_lcd_orientation=


### PR DESCRIPTION
This reverts commit c58047ce86c2f65d8561c7ae7340429808a2acaa.

lab-general用了你這個做法 
其他ARM處理器的機種無法編譯
先撤掉
我另開一個Android bugfix給你pull
