### PR TITLE
continue fix android mad ui:

### DIFF
--- a/apps/misc.c
+++ b/apps/misc.c
@@ -528,13 +528,13 @@ long default_event_handler_ex(long event, void (*callback)(void *), void *parame
 #if CONFIG_PLATFORM & (PLATFORM_ANDROID|PLATFORM_MAEMO)
     static bool resume = false;
 #endif
-
     void ((*func)(void));
     switch(event)
     {
         case SYS_JNI_CALL:
             func = (void *)button_get_data();
             func();
+            queue_remove_from_head(&button_queue, (long)func);
             break;
         case SYS_BATTERY_UPDATE:
             if(global_settings.talk_battery_level)

--- a/apps/settings.c
+++ b/apps/settings.c
@@ -110,6 +110,11 @@ struct system_status global_status;
 #include "usb-ibasso.h"
 #endif
 
+#if CONFIG_PLATFORM & PLATFORM_ANDROID
+#include "kernel.h"
+#include "button.h"
+extern void jni_call(void(*fn)(void));
+#endif
 
 long lasttime = 0;
 
@@ -773,7 +778,11 @@ void settings_apply_play_freq(int value, bool playback)
 }
 #endif /* HAVE_PLAY_FREQ */
 
+#if CONFIG_PLATFORM & PLATFORM_ANDROID
+static void _sound_settings_apply(void)
+#else
 void sound_settings_apply(void)
+#endif
 {
 #ifdef AUDIOHW_HAVE_BASS
     sound_set(SOUND_BASS, global_settings.bass);
@@ -833,6 +842,13 @@ void sound_settings_apply(void)
     }
 #endif
 }
+
+#if CONFIG_PLATFORM & PLATFORM_ANDROID
+void sound_settings_apply(void)
+{
+    jni_call(_sound_settings_apply);
+}
+#endif
 
 void settings_apply(bool read_disk)
 {


### PR DESCRIPTION
use jni call for sound settings.
remove jni function pointer from head of button queue after used.