### PR TITLE
fix bug when generating rbversion.h

### DIFF
--- a/firmware/firmware.make
+++ b/firmware/firmware.make
@@ -57,4 +57,4 @@ ifneq ($(SVNVERSION),$(OLDSVNVERSION))
 endif
 
 $(BUILDDIR)/rbversion.h:
-	$(call PRINTS,GEN $(@F))$(TOOLSDIR)/genversion.sh $(BUILDDIR) $(SVNVERSION)
+	$(call PRINTS,GEN $(@F))$(TOOLSDIR)/genversion.sh $(BUILDDIR) "$(SVNVERSION)"


### PR DESCRIPTION
the version string contains "(Community Version)", the parentheses "()" and spaces " " will mislead the bash